### PR TITLE
Fix warning about signed/unsigned comparison

### DIFF
--- a/happyhttp.cpp
+++ b/happyhttp.cpp
@@ -179,7 +179,7 @@ struct in_addr *atoaddr( const char* address)
 
 	// First try nnn.nnn.nnn.nnn form
 	saddr.s_addr = inet_addr(address);
-	if (saddr.s_addr != -1)
+	if (saddr.s_addr != INADDR_NONE)
 		return &saddr;
 
 	host = gethostbyname(address);


### PR DESCRIPTION
Thought this might be a nice little fix - noticed when compiling an application with this dependency (with `-Wall`). 